### PR TITLE
Fix routes and add quiz admin page

### DIFF
--- a/app.py
+++ b/app.py
@@ -169,6 +169,7 @@ def inject_helpers():
     return {
         'current_user': find_user(session.get('user')),
         'find_user': find_user,
+        'find_course': find_course,
         'read_courses': read_courses,
         'read_quizzes': read_quizzes
     }

--- a/app.py
+++ b/app.py
@@ -85,6 +85,24 @@ def create_course(cid, title, desc, educator, status):
         'status': status
     })
 
+def set_course_status(cid, status):
+    rows = read_csv(COURSE_FILE)
+    changed = False
+    for r in rows:
+        if r.get('id') == cid:
+            r['status'] = status
+            changed = True
+    if changed:
+        path = csv_path(COURSE_FILE)
+        with open(path, 'w', newline='') as f:
+            writer = csv.DictWriter(
+                f,
+                fieldnames=['id', 'title', 'description', 'educator', 'status']
+            )
+            writer.writeheader()
+            writer.writerows(rows)
+    return changed
+
 
 def read_enrollments():
     return [SimpleNamespace(**e) for e in read_csv(ENROLL_FILE)]
@@ -222,7 +240,7 @@ def take_quiz(course_id):
             create_result(session['user'], q.id, sel, correct)
             if sel == correct:
                 score += 1
-        return render_template('quiz_result.html', score=score, total=len(quizzes))
+        return render_template('quiz_result.html', score=score, total=len(quizzes), course_id=course_id)
     return render_template('take_quiz.html', quizzes=quizzes)
 
 @app.route('/profile')
@@ -323,6 +341,16 @@ def admin_courses():
         )
         flash('Course submitted for approval', 'success')
     return render_template('admin_courses.html', courses=read_courses(), users=read_users())
+
+@app.route('/admin/approve_course/<course_id>')
+@login_required
+def approve_course(course_id):
+    user = find_user(session['user'])
+    if user.role != 'admin':
+        abort(403)
+    if set_course_status(course_id, 'active'):
+        flash('Course approved', 'success')
+    return redirect(url_for('admin_courses'))
 
 @app.route('/admin/quizzes', methods=['GET', 'POST'])
 @login_required

--- a/instance/courses.csv
+++ b/instance/courses.csv
@@ -1,1 +1,3 @@
-
+id,title,description,educator,status
+1,Intro to AI,Learn AI basics,admin,active
+2,Machine Learning,Explore ML algorithms,admin,active

--- a/instance/enrollments.csv
+++ b/instance/enrollments.csv
@@ -1,1 +1,1 @@
-
+username,course_id

--- a/instance/lectures.csv
+++ b/instance/lectures.csv
@@ -1,1 +1,1 @@
-
+course_id,video

--- a/instance/quiz_results.csv
+++ b/instance/quiz_results.csv
@@ -1,1 +1,1 @@
-
+username,quiz_id,selected,correct

--- a/instance/quizzes.csv
+++ b/instance/quizzes.csv
@@ -1,1 +1,1 @@
-
+id,course_id,question,options,answer

--- a/instance/videos.csv
+++ b/instance/videos.csv
@@ -1,1 +1,1 @@
-
+course_id,filename

--- a/templates/admin_courses.html
+++ b/templates/admin_courses.html
@@ -19,9 +19,9 @@
       <td>{{ c.status }}</td>
       <td>
         {% if c.status=='pending' %}
-          <a href="{{ url_for('approve_course', cid=c.id) }}" class="btn btn-sm btn-success">Approve</a>
+          <a href="{{ url_for('approve_course', course_id=c.id) }}" class="btn btn-sm btn-success">Approve</a>
         {% endif %}
-        <a href="{{ url_for('course_detail', cid=c.id) }}" class="btn btn-sm btn-primary">View</a>
+        <a href="{{ url_for('course_detail', course_id=c.id) }}" class="btn btn-sm btn-primary">View</a>
       </td>
     </tr>
     {% endfor %}

--- a/templates/admin_quizzes.html
+++ b/templates/admin_quizzes.html
@@ -1,0 +1,49 @@
+{% extends 'base.html' %}
+{% block title %}Manage Quizzes – Cortex.ai{% endblock %}
+{% block content %}
+<h2>Manage Quizzes</h2>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Course</th>
+      <th>Question</th>
+      <th>Answer</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for q in quizzes %}
+    <tr>
+      <td>{{ find_course(q.course_id).title if find_course(q.course_id) else q.course_id }}</td>
+      <td>{{ q.question }}</td>
+      <td>{{ q.answer }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+<div class="card shadow-sm p-4 mt-4">
+  <h5>Add New Quiz</h5>
+  <form method="post">
+    <div class="mb-3">
+      <label class="form-label">Course</label>
+      <select name="course_id" class="form-select">
+        {% for c in courses %}
+        <option value="{{ c.id }}">{{ c.title }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Question</label>
+      <input name="question" class="form-control" required>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Options (pipe-separated)</label>
+      <input name="options" class="form-control" required>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Answer</label>
+      <input name="answer" class="form-control" required>
+    </div>
+    <button class="btn btn-success">Create Quiz</button>
+  </form>
+</div>
+{% endblock %}

--- a/templates/catalog.html
+++ b/templates/catalog.html
@@ -9,7 +9,7 @@
       <div class="card-body d-flex flex-column">
         <h5 class="card-title">{{ c.title }}</h5>
         <p class="card-text flex-grow-1">{{ c.description }}</p>
-        <a href="{{ url_for('course_detail', cid=c.id) }}" class="btn btn-primary mt-2">View Details</a>
+        <a href="{{ url_for('course_detail', course_id=c.id) }}" class="btn btn-primary mt-2">View Details</a>
       </div>
     </div>
   </div>

--- a/templates/course_detail.html
+++ b/templates/course_detail.html
@@ -4,8 +4,8 @@
 <h2>{{ course.title }}</h2>
 <p>{{ course.description }}</p>
 {% if not enrolled %}
-  <a href="{{ url_for('enroll', cid=course.id) }}" class="btn btn-success">Enroll</a>
+  <a href="{{ url_for('enroll', course_id=course.id) }}" class="btn btn-success">Enroll</a>
 {% else %}
-  <a href="{{ url_for('lesson', cid=course.id) }}" class="btn btn-primary">Go to Lesson</a>
+  <a href="{{ url_for('lesson', course_id=course.id) }}" class="btn btn-primary">Go to Lesson</a>
 {% endif %}
 {% endblock %}

--- a/templates/educator_profile.html
+++ b/templates/educator_profile.html
@@ -7,7 +7,7 @@
   {% for c in courses %}
     <li class="list-group-item d-flex justify-content-between align-items-center">
       {{ c.title }} ({{ c.status }})
-      <a href="{{ url_for('course_detail', cid=c.id) }}" class="btn btn-sm btn-primary">View</a>
+      <a href="{{ url_for('course_detail', course_id=c.id) }}" class="btn btn-sm btn-primary">View</a>
     </li>
   {% endfor %}
 </ul>

--- a/templates/quiz_result.html
+++ b/templates/quiz_result.html
@@ -2,5 +2,5 @@
 {% block title %}Quiz Results – Cortex.ai{% endblock %}
 {% block content %}
 <h2>Your Score: {{ score }}/{{ total }}</h2>
-<a href="{{ url_for('course_detail', cid=quizzes[0].course_id) }}" class="btn btn-primary">Back to Course</a>
+<a href="{{ url_for('course_detail', course_id=course_id) }}" class="btn btn-primary">Back to Course</a>
 {% endblock %}

--- a/templates/student_profile.html
+++ b/templates/student_profile.html
@@ -11,7 +11,7 @@
         <div class="card-body d-flex flex-column">
           <h5 class="card-title">{{ course.title }}</h5>
           <p class="card-text flex-grow-1">{{ course.description }}</p>
-          <a href="{{ url_for('lesson', cid=course.id) }}" class="btn btn-outline-primary mt-2">View Lesson</a>
+          <a href="{{ url_for('lesson', course_id=course.id) }}" class="btn btn-outline-primary mt-2">View Lesson</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add helper to update course status and new `/admin/approve_course` route
- fix course_id parameters in templates
- create missing `admin_quizzes.html` page
- add course_id context to quiz results
- add headers to CSV data files

## Testing
- `python3 -m py_compile app.py`
- `pyflakes app.py`

------
https://chatgpt.com/codex/tasks/task_e_683f81a28db4832b9012e1da0d5f2109